### PR TITLE
Separate AWS Instance type parameter for Elk and Jmeter

### DIFF
--- a/cmd/elk-up
+++ b/cmd/elk-up
@@ -51,7 +51,7 @@ source ${TEST_DIR}/config
 source ${CMD_DIR}/verify
 
 # Launch the instance
-CMD="aws ec2 --profile ${AWS_PROFILE} run-instances --image-id ${AWS_AMI} --instance-type ${AWS_INSTANCE_TYPE} --key-name ${AWS_KEYPAIR} --security-groups ${AWS_SECURITY_GROUP} --count 1"
+CMD="aws ec2 --profile ${AWS_PROFILE} run-instances --image-id ${AWS_AMI} --instance-type ${AWS_ELK_INSTANCE_TYPE} --key-name ${AWS_KEYPAIR} --security-groups ${AWS_SECURITY_GROUP} --count 1"
 RET=$(${CMD})
 check $? "Starting ELK instance"
 echo ${RET} | jq -r . >> ${LOG_DIR}/elk-up.log

--- a/cmd/jmeter-add-instances
+++ b/cmd/jmeter-add-instances
@@ -56,7 +56,7 @@ source ${TEST_DIR}/config
 source ${CMD_DIR}/verify
 
 # Launch the instance(s)
-CMD="aws ec2 --profile ${AWS_PROFILE} run-instances --image-id ${AWS_AMI} --instance-type ${AWS_INSTANCE_TYPE} --key-name ${AWS_KEYPAIR} --security-groups ${AWS_SECURITY_GROUP} --count ${COUNT}"
+CMD="aws ec2 --profile ${AWS_PROFILE} run-instances --image-id ${AWS_AMI} --instance-type ${AWS_JMETER_INSTANCE_TYPE} --key-name ${AWS_KEYPAIR} --security-groups ${AWS_SECURITY_GROUP} --count ${COUNT}"
 RET=$(${CMD})
 check $? "Starting JMeter instance(s)"
 echo ${RET} | jq -r . >> ${LOG_DIR}/jmeter-up.log

--- a/cmd/jmeter-up
+++ b/cmd/jmeter-up
@@ -60,7 +60,7 @@ source ${TEST_DIR}/config
 source ${CMD_DIR}/verify
 
 # Launch the instance(s)
-CMD="aws ec2 --profile ${AWS_PROFILE} run-instances --image-id ${AWS_AMI} --instance-type ${AWS_INSTANCE_TYPE} --key-name ${AWS_KEYPAIR} --security-groups ${AWS_SECURITY_GROUP} --count ${COUNT}"
+CMD="aws ec2 --profile ${AWS_PROFILE} run-instances --image-id ${AWS_AMI} --instance-type ${AWS_JMETER_INSTANCE_TYPE} --key-name ${AWS_KEYPAIR} --security-groups ${AWS_SECURITY_GROUP} --count ${COUNT}"
 RET=$(${CMD})
 check $? "Starting JMeter instance(s)"
 echo ${RET} | jq -r . >> ${LOG_DIR}/jmeter-up.log

--- a/cmd/verify
+++ b/cmd/verify
@@ -85,8 +85,11 @@ fi
 if [[ -z ${AWS_AMI} ]]; then
     ERRORS+=("Mandatory parameter not defined in config file: AWS_AMI")
 fi
-if [[ -z ${AWS_INSTANCE_TYPE} ]]; then
-    ERRORS+=("Mandatory parameter not defined in config file: AWS_INSTANCE_TYPE")
+if [[ -z ${AWS_JMETER_INSTANCE_TYPE} ]]; then
+    ERRORS+=("Mandatory parameter not defined in config file: AWS_JMETER_INSTANCE_TYPE")
+fi
+if [[ -z ${AWS_ELK_INSTANCE_TYPE} ]]; then
+    ERRORS+=("Mandatory parameter not defined in config file: AWS_ELK_INSTANCE_TYPE")
 fi
 if [[ -z ${AWS_KEYPAIR} ]]; then
     ERRORS+=("Mandatory parameter not defined in config file: AWS_KEYPAIR")

--- a/template
+++ b/template
@@ -33,7 +33,11 @@ P12_PASSWORD=
 # The AMI to use for ELK and JMeter slaves. Must contain Docker
 # Should only require changing when the AMI is updated.
 AWS_AMI=ami-6a470c19
-AWS_INSTANCE_TYPE=m4.large
+
+# mandatory
+# The instance types to use for ELK and JMeter slaves.
+AWS_JMETER_INSTANCE_TYPE=m4.large
+AWS_ELK_INSTANCE_TYPE=m4.large
 
 # mandatory
 # This should be the name of the certificate PEM file used to access instances.


### PR DESCRIPTION
Update relevant commands and template file to now have separate parameters for jmeter and elk instance class types.